### PR TITLE
Make Vite ports configurable via env

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -3,3 +3,15 @@
 # With it, the limit rises to 5000 requests/hour.
 # Generate one at: https://github.com/settings/tokens (no scopes needed for public repos)
 VITE_GITHUB_TOKEN=
+
+# Fallback port used by local tooling when a more specific port is not set.
+# This does not affect browser-exposed env and is read by vite.config.js.
+PORT=3000
+
+# Port used by `vite dev` for the local development server.
+# This takes precedence over PORT for development.
+DEV_SERVER_PORT=3000
+
+# Port used by `vite preview` for the local preview server.
+# This takes precedence over PORT for preview runs.
+PREVIEW_SERVER_PORT=3000

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -1,37 +1,52 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 
-export default defineConfig({
-  plugins: [react()],
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
-      '@app': path.resolve(__dirname, './src/app'),
-      '@features': path.resolve(__dirname, './src/features'),
-      '@config': path.resolve(__dirname, './src/config'),
-      '@context': path.resolve(__dirname, './src/context'),
-      '@hooks': path.resolve(__dirname, './src/hooks'),
-      '@services': path.resolve(__dirname, './src/services'),
-      '@utils': path.resolve(__dirname, './src/utils'),
-    }
-  },
-  server: {
-    port: 3000,
-    open: true,
-    proxy: {
-      '/api/yahoo': {
-        target: 'https://query1.finance.yahoo.com',
-        changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/api\/yahoo/, ''),
-        headers: {
-          'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
+const parsePort = (value, fallback) => {
+  const port = Number.parseInt(value, 10)
+  return Number.isInteger(port) && port > 0 ? port : fallback
+}
+
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  const defaultPort = parsePort(env.PORT, 3000)
+  const devPort = parsePort(env.DEV_SERVER_PORT, defaultPort)
+  const previewPort = parsePort(env.PREVIEW_SERVER_PORT, defaultPort)
+
+  return {
+    plugins: [react()],
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './src'),
+        '@app': path.resolve(__dirname, './src/app'),
+        '@features': path.resolve(__dirname, './src/features'),
+        '@config': path.resolve(__dirname, './src/config'),
+        '@context': path.resolve(__dirname, './src/context'),
+        '@hooks': path.resolve(__dirname, './src/hooks'),
+        '@services': path.resolve(__dirname, './src/services'),
+        '@utils': path.resolve(__dirname, './src/utils'),
+      }
+    },
+    server: {
+      port: devPort,
+      open: true,
+      proxy: {
+        '/api/yahoo': {
+          target: 'https://query1.finance.yahoo.com',
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/api\/yahoo/, ''),
+          headers: {
+            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
+          }
         }
       }
+    },
+    preview: {
+      port: previewPort,
+    },
+    build: {
+      outDir: 'dist',
+      sourcemap: true
     }
-  },
-  build: {
-    outDir: 'dist',
-    sourcemap: true
   }
 })


### PR DESCRIPTION
## Summary
- load server ports from environment variables in Vite config
- support separate DEV_SERVER_PORT and PREVIEW_SERVER_PORT values with PORT as fallback
- document the new variables in client/.env.example

## Notes
- this PR only includes the Vite port configuration changes
- local client/.env is intentionally not included